### PR TITLE
Add media to album information

### DIFF
--- a/tests/data/test_music.html
+++ b/tests/data/test_music.html
@@ -4,7 +4,6 @@
 <title>Music List</title>
 </head>
 <body>
-<p>
 <h2>Audio Media</h2>
 <p>
 <a rel="lp">
@@ -41,6 +40,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">One More From The Road</a></h3>
@@ -81,6 +81,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Afterburner</a></h3>
@@ -107,6 +108,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Greatest Hits</a></h3>
@@ -144,6 +146,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">The Baroque Album</a></h3>
@@ -186,6 +189,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Who's Zoo</a></h3>
@@ -281,6 +285,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Arc Of A Diver</a></h3>
@@ -304,6 +309,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Back In The High Life</a></h3>
@@ -328,6 +334,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Let Me Up (I've Had Enough)"</a></h3>
@@ -355,6 +362,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Life</a></h3>
@@ -380,6 +388,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Loc-ed After Dark</a></h3>
@@ -408,6 +417,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Agents Of Fortune</a></h3>
@@ -434,6 +444,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Some Enchanted Evening</a></h3>
@@ -457,6 +468,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Closer Together</a></h3>
@@ -482,6 +494,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">The Nature Of The Beast</a></h3>
@@ -509,6 +522,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Back In Black</a></h3>
@@ -535,6 +549,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Not Fragile</a></h3>
@@ -560,6 +575,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Thank God It's Friday</a></h3>
@@ -629,6 +645,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Slippery When Wet</a></h3>
@@ -655,6 +672,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">American Dream</a></h3>
@@ -685,6 +703,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Perfect Strangers</a></h3>
@@ -709,6 +728,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">His Greatest Sides, Vol. 1</a></h3>
@@ -739,6 +759,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Watts In A Tank</a></h3>
@@ -766,6 +787,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Boomtown</a></h3>
@@ -791,6 +813,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Here At Last...</a></h3>
@@ -839,6 +862,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Under A Raging Moon</a></h3>
@@ -865,6 +889,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">False Accusations</a></h3>
@@ -890,6 +915,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">The Best Of</a></h3>
@@ -937,6 +963,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Here At Last Bee Gees Live</a></h3>
@@ -985,6 +1012,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Saturday Night Fever</a></h3>
@@ -1045,6 +1073,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">The Way It Is</a></h3>
@@ -1070,6 +1099,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Standing In The Dark</a></h3>
@@ -1096,6 +1126,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Every Breath You Take - The Singles</a></h3>
@@ -1124,6 +1155,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">The Game</a></h3>
@@ -1150,6 +1182,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Hi Infidelity</a></h3>
@@ -1176,6 +1209,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Talk Is Cheap</a></h3>
@@ -1203,6 +1237,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Robbie Robertson</a></h3>
@@ -1228,6 +1263,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Sgt. Pepper's Lonely Hearts Club Band</a></h3>
@@ -1333,6 +1369,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">SoundWaves</a></h3>
@@ -1381,6 +1418,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Starflight</a></h3>
@@ -1429,6 +1467,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Pieces Of Eight</a></h3>
@@ -1455,6 +1494,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Paradise Theater</a></h3>
@@ -1482,6 +1522,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Never Mind The Bollocks</a></h3>
@@ -1510,6 +1551,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Brother Where You Bound</a></h3>
@@ -1532,6 +1574,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Paris</a></h3>
@@ -1574,6 +1617,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Love At First Sting</a></h3>
@@ -1599,6 +1643,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">At The Feet Of The Moon</a></h3>
@@ -1623,6 +1668,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">The Yes Album</a></h3>
@@ -1656,6 +1702,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Iron Man The Musical</a></h3>
@@ -1684,6 +1731,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">This Note's For You</a></h3>
@@ -1710,6 +1758,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">The Joshua Tree</a></h3>
@@ -1737,6 +1786,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Riptide</a></h3>
@@ -1763,6 +1813,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Star Wars</a></h3>
@@ -1806,6 +1857,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Van Halen</a></h3>
@@ -1833,6 +1885,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Couldn't Stand The Weather</a></h3>
@@ -1857,6 +1910,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Vertigo-Sampler</a></h3>
@@ -1939,6 +1993,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Brothers In Arms</a></h3>
@@ -1964,6 +2019,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Nervous Night</a></h3>
@@ -1989,6 +2045,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Glass Houses</a></h3>
@@ -2015,6 +2072,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">52nd Street</a></h3>
@@ -2040,6 +2098,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Fugazi</a></h3>
@@ -2063,6 +2122,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">The Immaculate Collection</a></h3>
@@ -2106,6 +2166,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Archives</a></h3>
@@ -2168,6 +2229,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Eagles Live</a></h3>
@@ -2209,6 +2271,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">4</a></h3>
@@ -2235,6 +2298,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Moontan</a></h3>
@@ -2256,6 +2320,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Moving Pictures</a></h3>
@@ -2279,6 +2344,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Permanent Waves</a></h3>
@@ -2301,6 +2367,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Power Windows</a></h3>
@@ -2325,6 +2392,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Signals</a></h3>
@@ -2349,6 +2417,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Best Of Moe Koffman</a></h3>
@@ -2375,6 +2444,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Hi-Fi Jazz Session</a></h3>
@@ -2415,6 +2485,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Hemispheres</a></h3>
@@ -2445,6 +2516,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">All The World's A Stage</a></h3>
@@ -2490,6 +2562,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Know Your Jazz</a></h3>
@@ -2528,6 +2601,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Struttin' Down Royal Street</a></h3>
@@ -2554,6 +2628,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Original Sound Track Recording</a></h3>
@@ -2593,6 +2668,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Exit...Stage Left</a></h3>
@@ -2632,6 +2708,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">2112</a></h3>
@@ -2664,6 +2741,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">A Farewell To Kings</a></h3>
@@ -2686,6 +2764,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Bat Out Of Hell</a></h3>
@@ -2709,6 +2788,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Mars Needs Guitars!</a></h3>
@@ -2735,6 +2815,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">I Can't Stand Still</a></h3>
@@ -2762,6 +2843,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Greatest Hits/Live</a></h3>
@@ -2806,6 +2888,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Grace Under Pressure</a></h3>
@@ -2830,6 +2913,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">The Dream Academy</a></h3>
@@ -2856,6 +2940,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Ten Big Ones</a></h3>
@@ -2882,6 +2967,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Who Rocks Harder</a></h3>
@@ -2905,6 +2991,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Private Dancer</a></h3>
@@ -2930,6 +3017,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Hot Shots</a></h3>
@@ -2958,6 +3046,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">White City</a></h3>
@@ -2983,6 +3072,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Deep End Live!</a></h3>
@@ -3009,6 +3099,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Dimensions</a></h3>
@@ -3058,6 +3149,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Greatest Hits - Volume 2</a></h3>
@@ -3084,6 +3176,7 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Gord's Gold Volume II</a></h3>
@@ -3116,13 +3209,13 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Various: 02 Dance Music: Modernlife</a></h3>
 <h3><a rel="artist">Various Artists</a></h3>
 <h3>Mixed By <a rel="mixer">DJ Geoffe</a></h3>
 <h3><a rel="date">2000</a></h3>
-<a rel="side">
 <ol>
   <li><a rel="song">Sublimior</a><br>
       <b><a rel="song-artist">Rinocerose</a></b></li>
@@ -3154,13 +3247,12 @@
       (<a rel="song-mix">Charlie May Remix</a>)</li>
 </ol>
 </a>
-</a>
+</p>
 <p>
-<a rel="lp">
+<a rel="cd">
 <h3><a rel="title">Relaxing With The Classics</a></h3>
 <h3><a rel="artist">The London Symphony Orchestra</a></h3>
 <h3><a rel="date">2001</a></h3>
-<a rel="side">
 <ol>
   <li><a rel="song">Morning Mood</a><br>
       from <i><a rel="song-classical-work">Peer Gynt Suite</a></i><br>
@@ -3189,7 +3281,7 @@
       by <b><a rel="song-classical-composer">Tchaikovsky</a></b></li>
 </ol>
 </a>
-</a>
+</p>
 <p>
 <a rel="lp">
 <h3><a rel="title">Trance Nation America Two</a></h3>
@@ -3288,12 +3380,12 @@
 </ol>
 </a>
 </a>
+</p>
 <p>
-<a rel="lp">
+<a rel="cd">
 <h3><a rel="title">Harp Attack!</a></h3>
 <h3><a rel="artist">James Cotton</a>, <a rel="artist">Carey Bell</a>, <a rel="artist">Junior Wells</a>, <a rel="artist">Billy Branch</a></h3>
 <h3><a rel="date">1990</a></h3>
-<a rel="side">
 <ol>
   <li><a rel="song">Down Home Blues</a></li>
   <li><a rel="song">Who</a></li>
@@ -3308,6 +3400,6 @@
   <li><a rel="song">New Kid On The Block</a></li>
 </ol>
 </a>
-</a>
+</p>
 </body>
 </html>

--- a/tests/test_lps.py
+++ b/tests/test_lps.py
@@ -9,6 +9,7 @@ from app.lps.lps_objects import (
     Artists,
     LPs,
     LPException,
+    MediaType,
     Song,
     SongException,
     TrackList,
@@ -151,7 +152,7 @@ class LPTestCase(unittest.TestCase):
 
         album_artist = Artists().create_Artist('Various Artists')
         album_mixer = Artists().create_Artist('DJ Funk')
-        album = LPs().create_LP('Club Cutz Volume 3', artists=[album_artist], year=1992, mixer=album_mixer)
+        album = LPs().create_LP(MediaType.LP, 'Club Cutz Volume 3', artists=[album_artist], year=1992, mixer=album_mixer)
         album.add_track(track=track)
 
         # Test properties creation
@@ -168,15 +169,15 @@ class LPTestCase(unittest.TestCase):
 
         # Test error conditions
         with pytest.raises(TypeError):
-            album = LPs().create_LP('Club Cutz Volume 9', [album_artist], '1992')
+            album = LPs().create_LP(MediaType.LP, 'Club Cutz Volume 9', [album_artist], '1992')
         with pytest.raises(ArtistException):
-            album = LPs().create_LP('Club Cutz Volume 9', 'DC Magnet', 1992)
+            album = LPs().create_LP(MediaType.LP, 'Club Cutz Volume 9', 'DC Magnet', 1992)
         with pytest.raises(ArtistException):
-            album = LPs().create_LP('Club Cutz Volume 9', ['DC Magnet'], 1992)
+            album = LPs().create_LP(MediaType.LP, 'Club Cutz Volume 9', ['DC Magnet'], 1992)
         with pytest.raises(TrackListException):
             album.add_track('Hello')
         with pytest.raises(ArtistException):
-            album = LPs().create_LP('Club Cutz Volume 9', artists=[album_artist], year=1992, mixer='Hello')
+            album = LPs().create_LP(MediaType.LP, 'Club Cutz Volume 9', artists=[album_artist], year=1992, mixer='Hello')
 
         # Test string output
         expected_string = 'Club Cutz Volume 3\n'
@@ -216,7 +217,7 @@ class LPTestCase(unittest.TestCase):
         track_1.add_song(song_2)
         track_1.add_song(song_3)
 
-        album_1 = LPs().create_LP('Club Cutz Volume 3', artists=[artist_1], year=1992)
+        album_1 = LPs().create_LP(MediaType.LP, 'Club Cutz Volume 3', artists=[artist_1], year=1992)
         album_1.add_track(track=track_1)
 
         song_4 = Song('He\'s All I Want', artist_5, mix='Cappery Mix')
@@ -227,7 +228,7 @@ class LPTestCase(unittest.TestCase):
         track_2.add_song(song_5)
         track_2.add_song(song_6)
         album_2_artist = Artists().create_Artist('Various Artists')
-        album_2 = LPs().create_LP('Various: 01 Dance Music: Modernlife', artists=[album_2_artist], year=2000)
+        album_2 = LPs().create_LP(media_type=MediaType.LP, title='Various: 01 Dance Music: Modernlife', artists=[album_2_artist], year=2000)
         album_2.add_track(track_2)
 
         # Test Singleton
@@ -236,7 +237,11 @@ class LPTestCase(unittest.TestCase):
 
         # Test existence
         self.assertTrue(all_lps.lp_exists(album_2))
-        missing_album = LPs().create_LP('Missing Gold', artists=[Artists().create_Artist('The Gold Diggers', skip_adding_to_artists_set=True)], year=1920, skip_adding_to_lp_list=True)
+        missing_album = LPs().create_LP(media_type=MediaType.LP,
+                                        title='Missing Gold',
+                                        artists=[Artists().create_Artist('The Gold Diggers', skip_adding_to_artists_set=True)],
+                                        year=1920,
+                                        skip_adding_to_lp_list=True)
         self.assertFalse(all_lps.lp_exists(missing_album))
 
         # Test we can only add valid albums
@@ -278,7 +283,7 @@ class LPTestCase(unittest.TestCase):
 
         # Test that we correctly create a new album when the title matches an
         # existing album
-        new_album = LPs().create_LP('Club Cutz Volume 3', artists=[artist_2], year=1992)
+        new_album = LPs().create_LP(media_type=MediaType.LP, title='Club Cutz Volume 3', artists=[artist_2], year=1992)
         self.assertNotEqual(album_1, new_album)
         search_results = all_lps.find_lp_by_title('Club Cutz Volume 3')
         self.assertEqual(2, len(search_results))
@@ -291,7 +296,7 @@ class LPTestCase(unittest.TestCase):
         self.assertIsNotNone(artists.find_artist('The Movement'))
         self.assertEqual(artist_2, artists.find_artist('Dannii Minogue'))
 
-    def test_reads_lps_html(self):
+    def test_read_lps_html(self):
         # Test the reading of a music html file to extract all the LPs
         all_artists = Artists()
         all_artists._clean_artists()


### PR DESCRIPTION
Test data needed to be update to enclose music album information into a <p></p> block.

For CDs, need to account for the lack of a <a rel="side"> tag.